### PR TITLE
Fix Inno Setup file

### DIFF
--- a/Installer.iss
+++ b/Installer.iss
@@ -266,8 +266,7 @@ begin
      SamePath(LegacyAppsDir, VoiceAttack2AppsDir) then
   begin
     Log(Format(
-      'VoiceAttack and VoiceAttack 2 are registered to the same Apps folder: "%s".',
-      [LegacyAppsDir]));
+      'VoiceAttack and VoiceAttack 2 are registered to the same Apps folder: "%s".', [LegacyAppsDir]));
     exit;
   end;
 


### PR DESCRIPTION
Fixes typo in commit [3ec2e4d](https://github.com/EDCD/EDDI/commit/3ec2e4d840f095c4a2baa0b9148a295bd1f3ef16)

Removed extraneous carriage return. Fixes log message formatting in Installer.iss 
Extra CR/LF caused error in Inno setup compiler 

`Line270: invalid section tag.`